### PR TITLE
Add PostgreSQL 16/17 support

### DIFF
--- a/smlar_gist.c
+++ b/smlar_gist.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "smlar.h"
 
 #include "fmgr.h"
@@ -430,7 +431,7 @@ Datum
 gsmlsign_decompress(PG_FUNCTION_ARGS)
 {
 	GISTENTRY	*entry = (GISTENTRY *) PG_GETARG_POINTER(0);
-	SmlSign		*key =  (SmlSign*)DatumGetPointer(PG_DETOAST_DATUM(entry->key));
+	SmlSign		*key =  (SmlSign*) PG_DETOAST_DATUM(entry->key);
 
 	if (key != (SmlSign *) DatumGetPointer(entry->key))
 	{
@@ -822,7 +823,7 @@ gsmlsign_picksplit(PG_FUNCTION_ARGS)
 		costvector[j - 1].pos = j;
 		size_alpha = hemdistcache(&(cache[seed_1]), &(cache[j]));
 		size_beta = hemdistcache(&(cache[seed_2]), &(cache[j]));
-		costvector[j - 1].cost = Abs(size_alpha - size_beta);
+		costvector[j - 1].cost = abs(size_alpha - size_beta);
 	}
 	qsort((void *) costvector, maxoff, sizeof(SPLITCOST), comparecost);
 


### PR DESCRIPTION
Fix to error when build against PostgreSQL 16/17

```
 gsmlsign_decompress(PG_FUNCTION_ARGS)
 {
        GISTENTRY       *entry = (GISTENTRY *) PG_GETARG_POINTER(0);
-       SmlSign         *key =  (SmlSign*)DatumGetPointer(PG_DETOAST_DATUM(entry->key));
+       SmlSign         *key =  (SmlSign*) PG_DETOAST_DATUM(entry->key);
 
        if (key != (SmlSign *) DatumGetPointer(entry->key))
        {
@@ -822,7 +823,7 @@ gsmlsign_picksplit(PG_FUNCTION_ARGS)
                costvector[j - 1].pos = j;
                size_alpha = hemdistcache(&(cache[seed_1]), &(cache[j]));
                size_beta = hemdistcache(&(cache[seed_2]), &(cache[j]));
-               costvector[j - 1].cost = Abs(size_alpha - size_beta);
+               costvector[j - 1].cost = abs(size_alpha - size_beta);
        }
        qsort((void *) costvector, maxoff, sizeof(SPLITCOST), comparecost);
 
```